### PR TITLE
feat: add back-to-home button in session header

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -51,9 +51,9 @@ Recent decisions affecting future work:
 - Allow host to remove users from session (api)
 - Bill ID tap opens native share sheet (ui)
 - Bottom tabs with route-based navigation (ui)
+- Detect restaurant name and improve bill list UI (api)
 - First-time user getting started tutorial (ui)
 - Handle oversized receipt images (api)
-- Show AI disclaimer after OCR scan completes (api)
 
 ### Blockers/Concerns
 

--- a/.planning/todos/pending/2026-01-19-detect-restaurant-name-improve-bill-list.md
+++ b/.planning/todos/pending/2026-01-19-detect-restaurant-name-improve-bill-list.md
@@ -1,0 +1,22 @@
+---
+created: 2026-01-19T12:00
+title: Detect restaurant name and improve bill list UI
+area: api
+files:
+  - src/api/scan.ts
+  - src/components/BillList.tsx
+---
+
+## Problem
+
+The bill list currently shows bills without restaurant names, making it hard for users to identify which bill is which when they have multiple sessions. The OCR system already scans receipts but doesn't extract the restaurant/business name.
+
+Users need to quickly identify their bills by restaurant name rather than relying on dates or bill IDs alone.
+
+## Solution
+
+1. **API**: Extend the receipt scanning prompt to extract restaurant/business name from the receipt header
+2. **Database**: Add `restaurantName` field to bill schema
+3. **UI**: Display restaurant name prominently in the bill list items
+
+TBD: Confidence threshold for restaurant name extraction, fallback display when name not detected.

--- a/src/pages/Session.tsx
+++ b/src/pages/Session.tsx
@@ -365,18 +365,29 @@ export default function Session() {
         />
       ))}
 
-      {/* Tappable Session Code Header */}
-      <button
-        onClick={handleCopyCode}
-        className="sticky top-0 z-10 w-full p-4 bg-blue-50 border-b border-blue-100 text-center active:bg-blue-100 transition-colors"
-      >
-        <span className="text-2xl font-mono font-bold tracking-widest text-blue-600">
-          {session.code}
-        </span>
-        <p className="text-xs text-blue-500 mt-1">
-          {copied ? "Copied!" : "tap to copy code"}
-        </p>
-      </button>
+      {/* Sticky Header: back button + session code */}
+      <div className="sticky top-0 z-10 w-full flex items-center bg-blue-50 border-b border-blue-100">
+        <Link
+          to="/"
+          className="flex items-center justify-center w-12 h-full pl-3 py-4 text-blue-500 active:text-blue-700"
+          aria-label="Back to home"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M15 18l-6-6 6-6"/>
+          </svg>
+        </Link>
+        <button
+          onClick={handleCopyCode}
+          className="flex-1 py-4 pr-12 text-center active:bg-blue-100 transition-colors"
+        >
+          <span className="text-2xl font-mono font-bold tracking-widest text-blue-600">
+            {session.code}
+          </span>
+          <p className="text-xs text-blue-500 mt-1">
+            {copied ? "Copied!" : "tap to copy code"}
+          </p>
+        </button>
+      </div>
 
       {/* Single scroll content area */}
       <div className="p-4">


### PR DESCRIPTION
## Summary

- Adds a left-arrow `<Link to="/">` on the left side of the sticky session code header
- The session code tap-to-copy button is unchanged — it fills the remaining space, balanced with `pr-12` so the code stays visually centered
- Uses an inline SVG chevron (no extra dependency)

## Test plan

- [ ] Open a bill session — confirm the header shows a back arrow on the left and the session code centered
- [ ] Tap the arrow → navigates to `/` (home screen)
- [ ] Tap the session code → copies to clipboard as before
- [ ] Check on mobile viewport (≤28rem) — layout fits cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)