### PR TITLE
Fix oversized receipt images by using URL source instead of base64

### DIFF
--- a/convex/actions/parseReceipt.ts
+++ b/convex/actions/parseReceipt.ts
@@ -185,22 +185,12 @@ type ReceiptValidationResponse =
 export const parseReceipt = action({
   args: { storageId: v.id("_storage") },
   handler: async (ctx, args): Promise<ParsedReceipt> => {
-    // Get the image blob from Convex storage
-    const imageBlob = await ctx.storage.get(args.storageId);
-    if (!imageBlob) {
+    // Get a publicly-accessible URL for the image from Convex storage.
+    // Using a URL avoids base64 encoding, which would be subject to Claude's 5MB limit.
+    const imageUrl = await ctx.storage.getUrl(args.storageId);
+    if (!imageUrl) {
       throw new Error("Image not found in storage");
     }
-
-    // Convert blob to base64
-    const arrayBuffer = await imageBlob.arrayBuffer();
-    const base64 = Buffer.from(arrayBuffer).toString("base64");
-
-    // Determine media type from blob
-    const mediaType = imageBlob.type as
-      | "image/jpeg"
-      | "image/png"
-      | "image/gif"
-      | "image/webp";
 
     // Initialize Anthropic client (API key from environment)
     const anthropic = new Anthropic({
@@ -219,9 +209,8 @@ export const parseReceipt = action({
             {
               type: "image",
               source: {
-                type: "base64",
-                media_type: mediaType,
-                data: base64,
+                type: "url",
+                url: imageUrl,
               },
             },
             {

--- a/package-lock.json
+++ b/package-lock.json
@@ -83,7 +83,6 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -360,7 +359,6 @@
       "integrity": "sha512-NKBGBSIKUG584qrS1tyxVpX/AKJKQw5HgjYEnPLC0QsTw79JrGn+qUr8CXFb955Iy7GUdiiUv1rJ6JBGvaKb6w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@edge-runtime/primitives": "6.0.0"
       },
@@ -1516,7 +1514,6 @@
       "integrity": "sha512-powIePYMmC3ibL0UJ2i2s0WIbq6cg6UyVFQxSCpaPxxzAaziRfimGivjdF943sSGV6RADVbk0Nvlm5P/FB44Zg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1527,7 +1524,6 @@
       "integrity": "sha512-3MbSL37jEchWZz2p2mjntRZtPt837ij10ApxKfgmXCTuHWagYg7iA5bqPw6C8BMPfwidlvfPI/fxOc42HLhcyg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1789,7 +1785,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -1847,7 +1842,6 @@
       "resolved": "https://registry.npmjs.org/convex/-/convex-1.31.4.tgz",
       "integrity": "sha512-iDm283Gb/CFRb30cvhH6Z9qlYof6dhtin415FarKUKB3K7gumO0rn8snY0CTvUrThV3UnCtttbuL/1oY7LscyA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "esbuild": "0.27.0",
         "prettier": "^3.0.0"
@@ -2476,7 +2470,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2550,7 +2543,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -2587,7 +2579,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2597,7 +2588,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -2874,7 +2864,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",


### PR DESCRIPTION
Switch parseReceipt action to pass a Convex storage URL directly to the
Claude Vision API instead of downloading the blob and base64-encoding it.
This bypasses Claude's 5MB base64 limit transparently for users uploading
large phone camera photos.

Closes #10

https://claude.ai/code/session_01JGYkxAYLY9HoeRPPnkwjma