### PR TITLE
Fix ugly error display when joining with duplicate name

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -144,8 +144,8 @@ export default function Home() {
       // Parse Convex error messages to extract user-friendly portion
       let errorMessage = isJoinMode ? "Failed to join bill" : "Failed to create bill";
       if (err instanceof Error) {
-        const match = err.message.match(/Uncaught Error:\s*(.+)$/);
-        errorMessage = match ? match[1] : err.message;
+        const match = err.message.match(/Uncaught Error:\s*([^\n]+)/);
+        errorMessage = match ? match[1] : err.message.split("\n")[0];
       }
       setJoinError(errorMessage);
       setIsSubmitting(false);


### PR DESCRIPTION
The regex used to parse Convex error messages used `.+$` which requires
the match to extend to end-of-string. When Convex error messages include
newlines (e.g. stack traces), `.+` stops at the first newline so the `$`
anchor never matches, causing the full raw error to be displayed instead
of the user-friendly message.

Fixes #3

https://claude.ai/code/session_014bw6B4aMfEhT8wfD2CPG3t