### PR TITLE
Add QR code header button and /bill/:code/qr route

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "convex": "^1.36.1",
         "react": "^19.2.3",
         "react-dom": "^19.2.3",
+        "react-qr-code": "^2.0.21",
         "react-router": "^7.12.0"
       },
       "devDependencies": {
@@ -871,9 +872,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -886,9 +884,6 @@
       "integrity": "sha512-grPNWydeKtc1aEdrJDWk4opD7nFtQbMmV7769hiAaYyUKCT1faPRm2av8CX1YJsZ4TLAZcg9gTR1KvEzoLjXkg==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -903,9 +898,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -918,9 +910,6 @@
       "integrity": "sha512-puS1MEgWX5GsHSoiAsF0TYrpomdvkaXm0CofIMG5uVkP6IBV+ZO9xhC5YEN49nsgYo1DuuMquF9+7EDBVYu4uA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -935,9 +924,6 @@
       "cpu": [
         "loong64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -950,9 +936,6 @@
       "integrity": "sha512-MR8c0+UxAlB22Fq4R+aQSPBayvYa3+9DrwG/i1TKQXFYEaoW3B5b/rkSRIypcZDdWjWnpcvxbNaAJDcSbJU3Lw==",
       "cpu": [
         "loong64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -967,9 +950,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -982,9 +962,6 @@
       "integrity": "sha512-ziR1OuZx0vdYZZ30vueNZTg73alF59DicYrPViG0NEgDVN8/Jl87zkAPu4u6VjZST2llgEUjaiNl9JM6HH1Vdw==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -999,9 +976,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1014,9 +988,6 @@
       "integrity": "sha512-u9yZ0jUkOED1BFrqu3BwMQoixvGHGZ+JhJNkNKY/hyoEgOwlqKb62qu+7UjbPSHYjiVy8kKJHvXKv5coH4wDeg==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1031,9 +1002,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1047,9 +1015,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1062,9 +1027,6 @@
       "integrity": "sha512-bD+zjpFrMpP/hqkfEcnjXWHMw5BIghGisOKPj+2NaNDuVT+8Ds4mPf3XcPHuat1tz89WRL+1wbcxKY3WSbiT7w==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1274,9 +1236,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1292,9 +1251,6 @@
       "integrity": "sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1312,9 +1268,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1330,9 +1283,6 @@
       "integrity": "sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1954,7 +1904,6 @@
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/jsesc": {
@@ -2122,9 +2071,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2144,9 +2090,6 @@
       "integrity": "sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -2168,9 +2111,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2190,9 +2130,6 @@
       "integrity": "sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -2247,6 +2184,18 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "dev": true,
@@ -2287,6 +2236,15 @@
       "version": "2.0.27",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/obug": {
       "version": "2.1.1",
@@ -2402,6 +2360,23 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/qr.js": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/qr.js/-/qr.js-0.0.0.tgz",
+      "integrity": "sha512-c4iYnWb+k2E+vYpRimHqSu575b1/wKl4XFeJGpFmrJQz5I88v9aY2czh7s0w36srfCM1sXgC/xpoJz5dJfq+OQ==",
+      "license": "MIT"
+    },
     "node_modules/react": {
       "version": "19.2.3",
       "license": "MIT",
@@ -2417,6 +2392,25 @@
       },
       "peerDependencies": {
         "react": "^19.2.3"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
+    "node_modules/react-qr-code": {
+      "version": "2.0.21",
+      "resolved": "https://registry.npmjs.org/react-qr-code/-/react-qr-code-2.0.21.tgz",
+      "integrity": "sha512-xaywjo0eaF4S3LOz6ns5eoPbM2E+q9HYl4VATYpxK4bBniOhQ9noY2RJ9G4SnZFhUwzx63FUT6KdHzfKgUwyuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.8.1",
+        "qr.js": "0.0.0"
+      },
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-refresh": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "convex": "^1.36.1",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
+    "react-qr-code": "^2.0.21",
     "react-router": "^7.12.0"
   },
   "devDependencies": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,8 @@
 import { BrowserRouter, Routes, Route } from "react-router";
 import Layout from "./components/Layout";
+import Items from "./components/Items";
+import TaxTipSettings from "./components/TaxTipSettings";
+import Summary from "./components/Summary";
 import Home from "./pages/Home";
 import Session from "./pages/Session";
 
@@ -9,7 +12,11 @@ function App() {
       <Routes>
         <Route path="/" element={<Layout />}>
           <Route index element={<Home />} />
-          <Route path="bill/:code" element={<Session />} />
+          <Route path="bill/:code" element={ <Session /> }>
+            <Route path="items" element={ <Items /> } />
+            <Route path="taxtip" element={ <TaxTipSettings /> } />
+            <Route path="summary" element={ <Summary /> } />
+          </Route>
         </Route>
       </Routes>
     </BrowserRouter>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,10 +12,10 @@ function App() {
       <Routes>
         <Route path="/" element={<Layout />}>
           <Route index element={<Home />} />
-          <Route path="bill/:code" element={ <Session /> }>
-            <Route path="items" element={ <Items /> } />
-            <Route path="taxtip" element={ <TaxTipSettings /> } />
-            <Route path="summary" element={ <Summary /> } />
+          <Route path="bill/:code" element={<Session />}>
+            <Route path="items" element={<Items />} />
+            <Route path="taxtip" element={<TaxTipSettings />} />
+            <Route path="summary" element={<Summary />} />
           </Route>
         </Route>
       </Routes>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import TaxTipSettings from "./components/TaxTipSettings";
 import Summary from "./components/Summary";
 import Home from "./pages/Home";
 import Session from "./pages/Session";
+import QrCode from "./pages/QrCode";
 
 function App() {
   return (
@@ -16,6 +17,7 @@ function App() {
             <Route path="items" element={<Items />} />
             <Route path="taxtip" element={<TaxTipSettings />} />
             <Route path="summary" element={<Summary />} />
+            <Route path="qr" element={<QrCode />} />
           </Route>
         </Route>
       </Routes>

--- a/src/components/Items.tsx
+++ b/src/components/Items.tsx
@@ -1,15 +1,46 @@
+import { useState } from "react";
+import { useOutletContext } from "react-router";
+import { useAction, useMutation } from "convex/react";
+import { api } from "../../convex/_generated/api";
 import ReceiptCapture from "../components/ReceiptCapture";
 import ClaimableItem from "../components/ClaimableItem";
-import { useOutletContext } from "react-router";
+import ReceiptImageViewer from "../components/ReceiptImageViewer";
+import { updateMerchantNameInBillHistory } from "../lib/billHistory";
+
+// Receipt processing state machine
+type ReceiptState =
+  | { step: "idle" }
+  | { step: "uploading" }
+  | { step: "processing"; storageId: Id<"_storage"> }
+  | { step: "error"; message: string };
+
+// Confidence threshold for handwritten tip pre-fill (higher than receipt validation)
+const HANDWRITTEN_TIP_CONFIDENCE_THRESHOLD = 0.8;
+
+// Map rejection reasons to user-friendly error messages
+const REJECTION_MESSAGES: Record<string, { title: string; hint: string }> = {
+  landscape_photo: {
+    title: "This doesn't look like a receipt",
+    hint: "Try taking a photo of your receipt instead",
+  },
+  document: {
+    title: "This looks like a document, not a receipt",
+    hint: "Make sure you're photographing a store receipt",
+  },
+  blurry: {
+    title: "The image is too blurry",
+    hint: "Try taking another photo with better lighting",
+  },
+  other: {
+    title: "We couldn't recognize this as a receipt",
+    hint: "Try taking a clearer photo of your receipt",
+  },
+};
 
 export default function Items () {
   const context = useOutletContext();
   const {
-    activeTab,
     participants,
-    receiptState,
-    handleReceiptUpload,
-    handleRetry,
     items,
     session,
     draftItem,
@@ -18,6 +49,156 @@ export default function Items () {
     isHost,
     groupSubtotal,
   } = context;
+
+  // Draft item state - local only until saved
+  const [draftItem, setDraftItem] = useState<{
+    name: string;
+    price: number;
+    quantity: number;
+  } | null>(null);
+
+  const [receiptState, setReceiptState] = useState<ReceiptState>({
+    step: "idle",
+  });
+
+  const [showReceiptImage, setShowReceiptImage] = useState(false);
+
+  // Parse receipt action and mutations for saving items directly
+  const parseReceipt = useAction(api.actions.parseReceipt.parseReceipt);
+  const addBulk = useMutation(api.items.addBulk);
+  const addBulkFees = useMutation(api.fees.addBulk);
+  const updateTip = useMutation(api.sessions.updateTip);
+  const addItem = useMutation(api.items.add);
+  const updateMerchant = useMutation(api.sessions.updateMerchant);
+
+  // Handle receipt upload - triggers OCR processing and saves items directly
+  async function handleReceiptUpload(storageId: Id<"_storage">) {
+    if (!session) return;
+    setReceiptState({ step: "processing", storageId });
+
+    try {
+      const result = await parseReceipt({ storageId });
+
+      if ("error" in result) {
+        // Check for validation rejection (non-receipt)
+        if ("rejection_reason" in result && result.rejection_reason) {
+          const msg =
+            REJECTION_MESSAGES[result.rejection_reason] ||
+            REJECTION_MESSAGES.other;
+          setReceiptState({
+            step: "error",
+            message: `${msg.title}\n\n${msg.hint}`,
+          });
+          return;
+        }
+        // Existing parse error handling
+        const rawPreview =
+          "raw" in result && result.raw
+            ? `\n\nRaw response: ${result.raw.slice(0, 500)}`
+            : "";
+        setReceiptState({
+          step: "error",
+          message: `OCR failed: ${result.error}.${rawPreview}`,
+        });
+        return;
+      }
+
+      // Convert prices from dollars to cents and save items directly
+      const itemsInCents = result.items.map((item) => ({
+        name: item.name,
+        price: Math.round(item.price * 100),
+        quantity: item.quantity,
+      }));
+
+      if (!currentParticipantId) {
+        throw new Error("Must be joined to upload receipt");
+      }
+      await addBulk({
+        sessionId: session._id,
+        items: itemsInCents,
+        participantId: currentParticipantId,
+      });
+
+      if (result.merchant) {
+        await updateMerchant({
+          sessionId: session._id,
+          participantId: currentParticipantId,
+          merchant: result.merchant,
+        });
+        if (code) {
+          updateMerchantNameInBillHistory(code, result.merchant);
+        }
+      }
+
+      // Add fees from receipt (convert to cents)
+      if (result.fees && result.fees.length > 0) {
+        const feesInCents = result.fees.map((fee) => ({
+          label: fee.label,
+          amount: Math.round(fee.amount * 100),
+        }));
+        await addBulkFees({
+          sessionId: session._id,
+          participantId: currentParticipantId,
+          fees: feesInCents,
+        });
+      }
+
+      // Pre-fill tip from handwritten detection (silent - no toast per user decision)
+      if (
+        "handwritten_tip" in result &&
+        result.handwritten_tip?.detected &&
+        result.handwritten_tip.amount !== null &&
+        result.handwritten_tip.confidence >=
+          HANDWRITTEN_TIP_CONFIDENCE_THRESHOLD
+      ) {
+        await updateTip({
+          sessionId: session._id,
+          tipType: "manual",
+          tipValue: Math.round(result.handwritten_tip.amount * 100), // convert dollars to cents
+          participantId: currentParticipantId,
+        });
+      }
+
+      // Reset to idle - items are now visible via real-time query
+      setReceiptState({ step: "idle" });
+    } catch (error) {
+      setReceiptState({
+        step: "error",
+        message:
+          error instanceof Error ? error.message : "Unknown error occurred",
+      });
+    }
+  }
+
+  // Handle retry after error
+  function handleRetry() {
+    setReceiptState({ step: "idle" });
+  }
+
+  // Draft item handlers
+  async function handleDraftSave(
+    name: string,
+    price: number,
+    quantity: number,
+  ) {
+    if (!session || !currentParticipantId) return;
+    await addItem({
+      sessionId: session._id,
+      participantId: currentParticipantId,
+      name,
+      price,
+      quantity,
+    });
+    setDraftItem(null);
+  }
+
+  function handleDraftCancel() {
+    setDraftItem(null);
+  }
+
+  function handleDraftChange(name: string, price: number, quantity: number) {
+    setDraftItem({ name, price, quantity });
+  }
 
   return (
     <div className="p-4">
@@ -212,6 +393,15 @@ export default function Items () {
           )}
         </div>
       </div>
+
+      {/* Receipt Image Viewer Modal */}
+      {session.receiptImageId && showReceiptImage && (
+        <ReceiptImageViewer
+          sessionId={session._id}
+          storageId={session.receiptImageId}
+          onClose={() => setShowReceiptImage(false)}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/Items.tsx
+++ b/src/components/Items.tsx
@@ -39,7 +39,7 @@ const REJECTION_MESSAGES: Record<string, { title: string; hint: string }> = {
   },
 };
 
-export default function Items () {
+export default function Items() {
   const context: Context = useOutletContext();
   const {
     participants,
@@ -369,9 +369,7 @@ export default function Items () {
 
           {/* Add item button - available to all participants */}
           <button
-            onClick={() =>
-              setDraftItem({ name: "", price: 0, quantity: 1 })
-            }
+            onClick={() => setDraftItem({ name: "", price: 0, quantity: 1 })}
             disabled={draftItem !== null}
             className={`w-full mt-2 py-3 px-4 border-2 border-dashed rounded-lg transition-colors ${
               draftItem !== null

--- a/src/components/Items.tsx
+++ b/src/components/Items.tsx
@@ -2,10 +2,12 @@ import { useState } from "react";
 import { useOutletContext } from "react-router";
 import { useAction, useMutation } from "convex/react";
 import { api } from "../../convex/_generated/api";
+import { Id } from "../../convex/_generated/dataModel";
 import ReceiptCapture from "../components/ReceiptCapture";
 import ClaimableItem from "../components/ClaimableItem";
 import ReceiptImageViewer from "../components/ReceiptImageViewer";
 import { updateMerchantNameInBillHistory } from "../lib/billHistory";
+import { Context } from "../pages/Session";
 
 // Receipt processing state machine
 type ReceiptState =
@@ -38,7 +40,7 @@ const REJECTION_MESSAGES: Record<string, { title: string; hint: string }> = {
 };
 
 export default function Items () {
-  const context = useOutletContext();
+  const context: Context = useOutletContext();
   const {
     participants,
     items,
@@ -124,8 +126,8 @@ export default function Items () {
           participantId: currentParticipantId,
           merchant: result.merchant,
         });
-        if (code) {
-          updateMerchantNameInBillHistory(code, result.merchant);
+        if (session.code) {
+          updateMerchantNameInBillHistory(session.code, result.merchant);
         }
       }
 
@@ -200,8 +202,7 @@ export default function Items () {
   }
 
   return (
-    <div className="p-4">
-      {/* Items Tab */}
+    <div className="p-4 space-y-4">
       <div>
         {/* Who's Here section */}
         {participants && participants.length > 0 && (

--- a/src/components/Items.tsx
+++ b/src/components/Items.tsx
@@ -1,0 +1,217 @@
+import ReceiptCapture from "../components/ReceiptCapture";
+import ClaimableItem from "../components/ClaimableItem";
+import { useOutletContext } from "react-router";
+
+export default function Items () {
+  const context = useOutletContext();
+  const {
+    activeTab,
+    participants,
+    receiptState,
+    handleReceiptUpload,
+    handleRetry,
+    items,
+    session,
+    draftItem,
+    claims,
+    currentParticipantId,
+    isHost,
+    groupSubtotal,
+  } = context;
+
+  return (
+    <div className="p-4">
+      {/* Items Tab */}
+      <div>
+        {/* Who's Here section */}
+        {participants && participants.length > 0 && (
+          <div className="mb-3">
+            <h2 className="text-lg font-semibold mb-2">
+              Who's Here ({participants.length})
+            </h2>
+            <div className="flex flex-wrap gap-1.5">
+              {[...participants]
+                .sort((a, b) => a.joinedAt - b.joinedAt)
+                .map((participant) => (
+                  <div
+                    key={participant._id}
+                    className="flex items-center gap-1 px-2 py-0.5 bg-gray-100 rounded-full text-sm"
+                  >
+                    <span className="font-medium">{participant.name}</span>
+                    {participant.isHost && (
+                      <span className="text-xs text-gray-500">(host)</span>
+                    )}
+                  </div>
+                ))}
+            </div>
+          </div>
+        )}
+
+        {/* Receipt section */}
+        <div className="mb-3">
+          <h2 className="text-lg font-semibold mb-2">Receipt</h2>
+
+          {/* Idle state: show capture UI */}
+          {receiptState.step === "idle" && (
+            <div>
+              {session.receiptImageId && (
+                <div className="mb-3">
+                  <p className="text-sm text-gray-600">
+                    Receipt uploaded. Upload a new one to replace existing
+                    items.
+                  </p>
+                  <button
+                    onClick={() => setShowReceiptImage(true)}
+                    className="text-sm text-blue-500 underline hover:text-blue-600"
+                  >
+                    View original receipt
+                  </button>
+                </div>
+              )}
+              <ReceiptCapture
+                sessionId={session._id}
+                onUpload={handleReceiptUpload}
+              />
+            </div>
+          )}
+
+          {/* Uploading state */}
+          {receiptState.step === "uploading" && (
+            <div className="text-center py-6">
+              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-500 mx-auto"></div>
+              <p className="mt-3 text-gray-600">Uploading...</p>
+            </div>
+          )}
+
+          {/* Processing state */}
+          {receiptState.step === "processing" && (
+            <div className="text-center py-6">
+              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-500 mx-auto"></div>
+              <p className="mt-3 text-gray-600">Analyzing receipt...</p>
+              <p className="text-sm text-gray-500 mt-1">
+                Extracting items with AI
+              </p>
+            </div>
+          )}
+
+          {/* Error state */}
+          {receiptState.step === "error" && (
+            <div className="text-center py-6">
+              <div className="text-red-500 mb-3">
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  className="h-12 w-12 mx-auto"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+                  />
+                </svg>
+              </div>
+              {receiptState.message.includes("\n\n") ? (
+                <>
+                  <p className="text-red-600 font-medium">
+                    {receiptState.message.split("\n\n")[0]}
+                  </p>
+                  <p className="text-sm text-gray-600 mt-1">
+                    {receiptState.message.split("\n\n")[1]}
+                  </p>
+                </>
+              ) : (
+                <>
+                  <p className="text-red-600 font-medium">
+                    Something went wrong
+                  </p>
+                  <p className="text-sm text-gray-600 mt-1">
+                    {receiptState.message}
+                  </p>
+                </>
+              )}
+              <button
+                onClick={handleRetry}
+                className="mt-4 px-4 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600 transition-colors"
+              >
+                Try Again
+              </button>
+            </div>
+          )}
+        </div>
+
+        {/* Items list */}
+        <div className="mb-3">
+          <div className="flex flex-row justify-between">
+            <h2 className="text-lg font-semibold mb-2">
+              Items {items && items.length > 0 ? `(${items.length})` : ""}
+            </h2>
+            <div className="text-sm text-gray-400 pt-1">
+              {session.merchant ? session.merchant : null}
+            </div>
+          </div>
+          <div className="space-y-1">
+            {items?.map((item) => (
+              <ClaimableItem
+                key={item._id}
+                item={item}
+                claims={(claims ?? []).filter((c) => c.itemId === item._id)}
+                participants={participants ?? []}
+                currentParticipantId={currentParticipantId}
+                isHost={isHost}
+              />
+            ))}
+          </div>
+
+          {/* Draft item - local only until saved */}
+          {draftItem && (
+            <ClaimableItem
+              item={{
+                _id: "" as Id<"items">,
+                sessionId: session._id,
+                name: draftItem.name,
+                price: draftItem.price,
+                quantity: draftItem.quantity,
+              }}
+              claims={[]}
+              participants={participants ?? []}
+              currentParticipantId={currentParticipantId}
+              isHost={isHost}
+              isDraft={true}
+              onDraftSave={handleDraftSave}
+              onDraftCancel={handleDraftCancel}
+              onDraftChange={handleDraftChange}
+            />
+          )}
+
+          {/* Add item button - available to all participants */}
+          <button
+            onClick={() =>
+              setDraftItem({ name: "", price: 0, quantity: 1 })
+            }
+            disabled={draftItem !== null}
+            className={`w-full mt-2 py-3 px-4 border-2 border-dashed rounded-lg transition-colors ${
+              draftItem !== null
+                ? "border-gray-200 text-gray-400 cursor-not-allowed"
+                : "border-gray-300 text-gray-600 hover:border-gray-400 hover:text-gray-700"
+            }`}
+          >
+            + Add Item
+          </button>
+
+          {/* Items total */}
+          {items && items.length > 0 && (
+            <div className="mt-2 pt-2 border-t border-gray-200 flex justify-between items-center">
+              <span className="font-medium">Items Total</span>
+              <span className="font-semibold">
+                ${(groupSubtotal / 100).toFixed(2)}
+              </span>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Items.tsx
+++ b/src/components/Items.tsx
@@ -43,7 +43,6 @@ export default function Items () {
     participants,
     items,
     session,
-    draftItem,
     claims,
     currentParticipantId,
     isHost,

--- a/src/components/Summary.tsx
+++ b/src/components/Summary.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { useQuery } from "convex/react";
 import { api } from "../../convex/_generated/api";
 import { Id } from "../../convex/_generated/dataModel";
+import { useOutletContext } from "react-router";
 
 interface SummaryProps {
   sessionId: Id<"sessions">;
@@ -12,7 +13,8 @@ export default function Summary({
   sessionId,
   currentParticipantId,
 }: SummaryProps) {
-  const totals = useQuery(api.participants.getTotals, { sessionId });
+  const context = useOutletContext();
+  const totals = useQuery(api.participants.getTotals, { sessionId: context.session._id });
   const [expandedParticipant, setExpandedParticipant] = useState<string | null>(
     null,
   );

--- a/src/components/Summary.tsx
+++ b/src/components/Summary.tsx
@@ -1,20 +1,14 @@
 import { useState } from "react";
 import { useQuery } from "convex/react";
 import { api } from "../../convex/_generated/api";
-import { Id } from "../../convex/_generated/dataModel";
 import { useOutletContext } from "react-router";
+import { Context } from "../pages/Session";
 
-interface SummaryProps {
-  sessionId: Id<"sessions">;
-  currentParticipantId: Id<"participants"> | null;
-}
+export default function Summary() {
+  const context: Context = useOutletContext();
+  const { session, currentParticipantId } = context;
 
-export default function Summary({
-  sessionId,
-  currentParticipantId,
-}: SummaryProps) {
-  const context = useOutletContext();
-  const totals = useQuery(api.participants.getTotals, { sessionId: context.session._id });
+  const totals = useQuery(api.participants.getTotals, { sessionId: session._id });
   const [expandedParticipant, setExpandedParticipant] = useState<string | null>(
     null,
   );
@@ -41,7 +35,7 @@ export default function Summary({
   }
 
   return (
-    <div className="space-y-4">
+    <div className="p-4 space-y-4">
       {/* Unclaimed Warning */}
       {unclaimedItems.length > 0 && (
         <div className="p-3 bg-yellow-50 border border-yellow-200 rounded-lg">

--- a/src/components/Summary.tsx
+++ b/src/components/Summary.tsx
@@ -8,7 +8,9 @@ export default function Summary() {
   const context: Context = useOutletContext();
   const { session, currentParticipantId } = context;
 
-  const totals = useQuery(api.participants.getTotals, { sessionId: session._id });
+  const totals = useQuery(api.participants.getTotals, {
+    sessionId: session._id,
+  });
   const [expandedParticipant, setExpandedParticipant] = useState<string | null>(
     null,
   );

--- a/src/components/TabNavigation.tsx
+++ b/src/components/TabNavigation.tsx
@@ -84,7 +84,7 @@ export default function TabNavigation({
                 const baseClasses = `flex-1 flex flex-col items-center justify-center py-2 min-h-[56px] transition-colors`
                 return isActive ?
                   baseClasses + " text-blue-600" :
-                  baseClasses + " text-black-500"
+                  baseClasses + " text-gray-500"
               }}
             >
               <div className="relative">

--- a/src/components/TabNavigation.tsx
+++ b/src/components/TabNavigation.tsx
@@ -1,3 +1,5 @@
+import { useLocation, NavLink } from "react-router";
+
 type Tab = "items" | "taxtip" | "summary";
 
 interface TabNavigationProps {
@@ -71,19 +73,24 @@ export default function TabNavigation({
     { id: "taxtip", label: "Tax & Tip", Icon: CalculatorIcon },
     { id: "summary", label: "Totals", Icon: UsersIcon },
   ];
+  const location = useLocation();
 
   return (
     <nav className="fixed bottom-0 left-0 right-0 bg-white border-t border-gray-200 pb-safe">
       <div className="max-w-md mx-auto flex">
         {tabs.map(({ id, label, Icon }) => {
-          const isActive = activeTab === id;
+          const isActive = location.pathname.endsWith(id);
           return (
-            <button
+            <NavLink
+              to={id}
               key={id}
-              onClick={() => onTabChange(id)}
-              className={`flex-1 flex flex-col items-center justify-center py-2 min-h-[56px] transition-colors ${
-                isActive ? "text-blue-600" : "text-gray-500"
-              }`}
+              onClick={() => onTabChange(id, location)}
+              className={({ isActive }) => {
+                const baseClasses = `flex-1 flex flex-col items-center justify-center py-2 min-h-[56px] transition-colors`
+                return isActive ?
+                  baseClasses + " text-blue-600" :
+                  baseClasses + " text-black-500"
+              }}
             >
               <div className="relative">
                 <Icon className="w-6 h-6" />
@@ -96,7 +103,7 @@ export default function TabNavigation({
               <span className={`text-xs mt-1 ${isActive ? "font-medium" : ""}`}>
                 {label}
               </span>
-            </button>
+            </NavLink>
           );
         })}
       </div>

--- a/src/components/TabNavigation.tsx
+++ b/src/components/TabNavigation.tsx
@@ -1,4 +1,4 @@
-import { useLocation, NavLink } from "react-router";
+import { NavLink } from "react-router";
 
 type Tab = "items" | "taxtip" | "summary";
 
@@ -69,13 +69,11 @@ export default function TabNavigation({
     { id: "taxtip", label: "Tax & Tip", Icon: CalculatorIcon },
     { id: "summary", label: "Totals", Icon: UsersIcon },
   ];
-  const location = useLocation();
 
   return (
     <nav className="fixed bottom-0 left-0 right-0 bg-white border-t border-gray-200 pb-safe">
       <div className="max-w-md mx-auto flex">
         {tabs.map(({ id, label, Icon }) => {
-          const isActive = location.pathname.endsWith(id);
           return (
             <NavLink
               to={id}
@@ -87,17 +85,21 @@ export default function TabNavigation({
                   baseClasses + " text-gray-500"
               }}
             >
-              <div className="relative">
-                <Icon className="w-6 h-6" />
-                {id === "items" && unclaimedCount > 0 && (
-                  <span className="absolute -top-1 -right-2 bg-red-500 text-white text-xs font-medium rounded-full min-w-[18px] h-[18px] flex items-center justify-center px-1">
-                    {unclaimedCount}
+              {({ isActive }) => (
+                <>
+                  <div className="relative">
+                    <Icon className="w-6 h-6" />
+                    {id === "items" && unclaimedCount > 0 && (
+                      <span className="absolute -top-1 -right-2 bg-red-500 text-white text-xs font-medium rounded-full min-w-[18px] h-[18px] flex items-center justify-center px-1">
+                        {unclaimedCount}
+                      </span>
+                    )}
+                  </div>
+                  <span className={`text-xs mt-1 ${isActive ? "font-medium" : ""}`}>
+                    {label}
                   </span>
-                )}
-              </div>
-              <span className={`text-xs mt-1 ${isActive ? "font-medium" : ""}`}>
-                {label}
-              </span>
+                </>
+              )}
             </NavLink>
           );
         })}

--- a/src/components/TabNavigation.tsx
+++ b/src/components/TabNavigation.tsx
@@ -3,7 +3,6 @@ import { useLocation, NavLink } from "react-router";
 type Tab = "items" | "taxtip" | "summary";
 
 interface TabNavigationProps {
-  activeTab: Tab;
   onTabChange: (tab: Tab) => void;
   unclaimedCount?: number;
 }
@@ -64,7 +63,6 @@ function UsersIcon({ className }: { className?: string }) {
 }
 
 export default function TabNavigation({
-  activeTab,
   onTabChange,
   unclaimedCount = 0,
 }: TabNavigationProps) {

--- a/src/components/TabNavigation.tsx
+++ b/src/components/TabNavigation.tsx
@@ -79,10 +79,10 @@ export default function TabNavigation({
               to={id}
               key={id}
               className={({ isActive }) => {
-                const baseClasses = `flex-1 flex flex-col items-center justify-center py-2 min-h-[56px] transition-colors`
-                return isActive ?
-                  baseClasses + " text-blue-600" :
-                  baseClasses + " text-gray-500"
+                const baseClasses = `flex-1 flex flex-col items-center justify-center py-2 min-h-[56px] transition-colors`;
+                return isActive
+                  ? baseClasses + " text-blue-600"
+                  : baseClasses + " text-gray-500";
               }}
             >
               {({ isActive }) => (
@@ -95,7 +95,9 @@ export default function TabNavigation({
                       </span>
                     )}
                   </div>
-                  <span className={`text-xs mt-1 ${isActive ? "font-medium" : ""}`}>
+                  <span
+                    className={`text-xs mt-1 ${isActive ? "font-medium" : ""}`}
+                  >
                     {label}
                   </span>
                 </>

--- a/src/components/TabNavigation.tsx
+++ b/src/components/TabNavigation.tsx
@@ -3,7 +3,6 @@ import { useLocation, NavLink } from "react-router";
 type Tab = "items" | "taxtip" | "summary";
 
 interface TabNavigationProps {
-  onTabChange: (tab: Tab) => void;
   unclaimedCount?: number;
 }
 
@@ -63,7 +62,6 @@ function UsersIcon({ className }: { className?: string }) {
 }
 
 export default function TabNavigation({
-  onTabChange,
   unclaimedCount = 0,
 }: TabNavigationProps) {
   const tabs: { id: Tab; label: string; Icon: typeof ListIcon }[] = [
@@ -82,7 +80,6 @@ export default function TabNavigation({
             <NavLink
               to={id}
               key={id}
-              onClick={() => onTabChange(id, location)}
               className={({ isActive }) => {
                 const baseClasses = `flex-1 flex flex-col items-center justify-center py-2 min-h-[56px] transition-colors`
                 return isActive ?

--- a/src/components/TaxTipSettings.tsx
+++ b/src/components/TaxTipSettings.tsx
@@ -2,29 +2,9 @@ import { useState, useEffect, useRef } from "react";
 import { useMutation } from "convex/react";
 import { useOutletContext } from "react-router";
 import { api } from "../../convex/_generated/api";
-import { Id } from "../../convex/_generated/dataModel";
 import { calculateTipShare } from "../../convex/calculations";
-
-interface Fee {
-  _id: Id<"fees">;
-  label: string;
-  amount: number;
-}
-
-interface Session {
-  _id: Id<"sessions">;
-  gratuity?: number;
-  tipType?: "percent_subtotal" | "percent_total" | "manual";
-  tipValue?: number;
-}
-
-interface TaxTipSettingsProps {
-  session: Session;
-  fees: Fee[];
-  isHost: boolean;
-  groupSubtotal: number; // in cents
-  participantId: Id<"participants"> | null;
-}
+import { Fee, Context } from "../pages/Session";
+import { Id } from "../../convex/_generated/dataModel";
 
 // Local state for each fee row
 interface FeeEditState {
@@ -33,15 +13,9 @@ interface FeeEditState {
 }
 
 export default function TaxTipSettings() {
-  const context = useOutletContext();
+  const context: Context = useOutletContext();
   const {
-    participants,
-    handleReceiptUpload,
-    handleRetry,
-    items,
     session,
-    draftItem,
-    claims,
     currentParticipantId,
     isHost,
     groupSubtotal,
@@ -131,7 +105,7 @@ export default function TaxTipSettings() {
   const updateTip = useMutation(api.sessions.updateTip);
 
   // Calculate total fees for preview
-  const totalFees = fees.reduce((sum, fee) => sum + fee.amount, 0);
+  const totalFees = fees.reduce((sum: number, fee: Fee) => sum + fee.amount, 0);
   const currentGratuity = gratuityInput
     ? Math.round(parseFloat(gratuityInput) * 100) || 0
     : 0;
@@ -169,23 +143,31 @@ export default function TaxTipSettings() {
   }
 
   async function handleFeeBlur(feeId: Id<"fees">, field: "label" | "amount") {
-    if (!participantId) return;
+    if (!currentParticipantId) return;
     const input = feeInputs.get(feeId);
     if (!input) return;
 
     if (field === "label") {
-      await updateFee({ feeId, participantId, label: input.label });
+      await updateFee({
+        feeId,
+        participantId: currentParticipantId,
+        label: input.label
+      });
     } else {
       const amountInCents = Math.round(parseFloat(input.amount) * 100) || 0;
-      await updateFee({ feeId, participantId, amount: amountInCents });
+      await updateFee({
+        feeId,
+        participantId: currentParticipantId,
+        amount: amountInCents
+      });
     }
   }
 
   async function handleAddFee() {
-    if (!participantId) return;
+    if (!currentParticipantId) return;
     const newFeeId = await addFee({
       sessionId: session._id,
-      participantId,
+      participantId: currentParticipantId,
       label: "New fee",
       amount: 0,
     });
@@ -193,15 +175,18 @@ export default function TaxTipSettings() {
   }
 
   async function handleRemoveFee(feeId: Id<"fees">) {
-    if (!participantId) return;
-    await removeFee({ feeId, participantId });
+    if (!currentParticipantId) return;
+    await removeFee({
+      feeId,
+      participantId: currentParticipantId
+    });
   }
 
   // Tip handlers
   async function handleTipTypeChange(
     newType: "percent_subtotal" | "percent_total" | "manual",
   ) {
-    if (!participantId) return;
+    if (!currentParticipantId) return;
     const oldType = tipType;
     setTipType(newType);
 
@@ -214,7 +199,7 @@ export default function TaxTipSettings() {
         sessionId: session._id,
         tipType: newType,
         tipValue: 0,
-        participantId,
+        participantId: currentParticipantId,
       });
     } else {
       const currentValue = parseFloat(tipInput) || 0;
@@ -222,13 +207,13 @@ export default function TaxTipSettings() {
         sessionId: session._id,
         tipType: newType,
         tipValue: currentValue,
-        participantId,
+        participantId: currentParticipantId,
       });
     }
   }
 
   async function handleTipBlur() {
-    if (!participantId) return;
+    if (!currentParticipantId) return;
     const tipValue =
       tipType === "manual"
         ? Math.round(parseFloat(tipInput) * 100) || 0
@@ -237,12 +222,12 @@ export default function TaxTipSettings() {
       sessionId: session._id,
       tipType,
       tipValue,
-      participantId,
+      participantId: currentParticipantId,
     });
   }
 
   return (
-    <div className="space-y-4">
+    <div className="p-4 space-y-4">
       {/* Taxes & Fees Section */}
       <div className="p-4 bg-gray-50 rounded-lg">
         <div className="flex justify-between items-center mb-3">
@@ -254,7 +239,7 @@ export default function TaxTipSettings() {
 
         {/* Fee list */}
         <div className="space-y-2">
-          {fees.map((fee) => {
+          {fees.map((fee: Fee) => {
             const input = feeInputs.get(fee._id) || {
               label: fee.label,
               amount: (fee.amount / 100).toFixed(2),

--- a/src/components/TaxTipSettings.tsx
+++ b/src/components/TaxTipSettings.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef } from "react";
 import { useMutation } from "convex/react";
+import { useOutletContext } from "react-router";
 import { api } from "../../convex/_generated/api";
 import { Id } from "../../convex/_generated/dataModel";
 import { calculateTipShare } from "../../convex/calculations";
@@ -31,13 +32,24 @@ interface FeeEditState {
   amount: string;
 }
 
-export default function TaxTipSettings({
-  session,
-  fees,
-  isHost,
-  groupSubtotal,
-  participantId,
-}: TaxTipSettingsProps) {
+export default function TaxTipSettings() {
+  const context = useOutletContext();
+  const {
+    activeTab,
+    participants,
+    receiptState,
+    handleReceiptUpload,
+    handleRetry,
+    items,
+    session,
+    draftItem,
+    claims,
+    currentParticipantId,
+    isHost,
+    groupSubtotal,
+    fees
+  } = context;
+
   // Local state for fee editing - keyed by fee ID
   const [feeInputs, setFeeInputs] = useState<Map<string, FeeEditState>>(
     new Map(),

--- a/src/components/TaxTipSettings.tsx
+++ b/src/components/TaxTipSettings.tsx
@@ -14,13 +14,8 @@ interface FeeEditState {
 
 export default function TaxTipSettings() {
   const context: Context = useOutletContext();
-  const {
-    session,
-    currentParticipantId,
-    isHost,
-    groupSubtotal,
-    fees
-  } = context;
+  const { session, currentParticipantId, isHost, groupSubtotal, fees } =
+    context;
 
   // Local state for fee editing - keyed by fee ID
   const [feeInputs, setFeeInputs] = useState<Map<string, FeeEditState>>(
@@ -151,14 +146,14 @@ export default function TaxTipSettings() {
       await updateFee({
         feeId,
         participantId: currentParticipantId,
-        label: input.label
+        label: input.label,
       });
     } else {
       const amountInCents = Math.round(parseFloat(input.amount) * 100) || 0;
       await updateFee({
         feeId,
         participantId: currentParticipantId,
-        amount: amountInCents
+        amount: amountInCents,
       });
     }
   }
@@ -178,7 +173,7 @@ export default function TaxTipSettings() {
     if (!currentParticipantId) return;
     await removeFee({
       feeId,
-      participantId: currentParticipantId
+      participantId: currentParticipantId,
     });
   }
 

--- a/src/components/TaxTipSettings.tsx
+++ b/src/components/TaxTipSettings.tsx
@@ -35,9 +35,7 @@ interface FeeEditState {
 export default function TaxTipSettings() {
   const context = useOutletContext();
   const {
-    activeTab,
     participants,
-    receiptState,
     handleReceiptUpload,
     handleRetry,
     items,

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -80,7 +80,7 @@ export default function Home() {
       storedParticipant.sessionId === joinSession._id
     ) {
       // Participant exists and belongs to this session - auto-redirect
-      navigate(`/bill/${code}`);
+      navigate(`/bill/${code}/items`);
     } else {
       // Participant doesn't exist or belongs to different session - clear storage
       clearParticipant(code);
@@ -129,7 +129,7 @@ export default function Home() {
           participantName: name.trim(),
           participantId,
         });
-        navigate(`/bill/${joinSession.code}`);
+        navigate(`/bill/${joinSession.code}/items`);
       } else {
         // Create new bill
         const { code: newCode, hostParticipantId } = await createSession({
@@ -145,7 +145,7 @@ export default function Home() {
           participantName: name.trim(),
           participantId: hostParticipantId,
         });
-        navigate(`/bill/${newCode}`);
+        navigate(`/bill/${newCode}/items`);
       }
     } catch (err) {
       // Parse Convex error messages to extract user-friendly portion
@@ -288,7 +288,7 @@ export default function Home() {
               {history.map((bill) => (
                 <Link
                   key={bill.code}
-                  to={`/bill/${bill.code}`}
+                  to={`/bill/${bill.code}/items`}
                   className="block p-3 bg-gray-50 rounded-lg hover:bg-gray-100 transition-colors"
                 >
                   <div className="flex justify-between items-center">

--- a/src/pages/QrCode.tsx
+++ b/src/pages/QrCode.tsx
@@ -1,0 +1,13 @@
+import { useParams } from "react-router";
+import QRCode from "react-qr-code";
+
+export default function QrCode() {
+  const { code } = useParams<{ code: string }>();
+  const shareUrl = `${window.location.origin}/bill/${code}`;
+
+  return (
+    <div className="flex items-center justify-center min-h-[calc(100vh-120px)] pb-24 px-8">
+      <QRCode value={shareUrl} size={240} />
+    </div>
+  );
+}

--- a/src/pages/Session.tsx
+++ b/src/pages/Session.tsx
@@ -223,7 +223,9 @@ export default function Session() {
   // Handle copying session code to clipboard
   async function handleCopyCode() {
     try {
-      await navigator.clipboard.writeText(window.location.href);
+      await navigator.clipboard.writeText(
+        `${window.location.origin}/bill/${code}`
+      );
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     } catch (err) {
@@ -278,8 +280,34 @@ export default function Session() {
           </p>
         </button>
 
-        {/* Spacer to balance back button width */}
-        <div className="w-[72px] shrink-0" />
+        {/* QR code button */}
+        <Link
+          to="qr"
+          className="flex items-center justify-center px-4 py-4 text-blue-600 hover:text-blue-800 active:text-blue-900 shrink-0 w-[72px]"
+          aria-label="Show QR code"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            className="h-5 w-5"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={2}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <rect x="3" y="3" width="7" height="7" />
+            <rect x="14" y="3" width="7" height="7" />
+            <rect x="3" y="14" width="7" height="7" />
+            <rect x="5" y="5" width="3" height="3" fill="currentColor" stroke="none" />
+            <rect x="16" y="5" width="3" height="3" fill="currentColor" stroke="none" />
+            <rect x="5" y="16" width="3" height="3" fill="currentColor" stroke="none" />
+            <path d="M14 14h3v3h-3z" fill="currentColor" stroke="none" />
+            <path d="M17 17h3v3h-3z" fill="currentColor" stroke="none" />
+            <path d="M14 20h3" />
+            <path d="M20 14v3" />
+          </svg>
+        </Link>
       </div>
 
       <div>

--- a/src/pages/Session.tsx
+++ b/src/pages/Session.tsx
@@ -1,14 +1,14 @@
 import { useState, useRef, useEffect, useMemo } from "react";
-import { useParams, Link } from "react-router";
+import { useParams, Link, Route, Outlet, useLocation } from "react-router";
 import { useQuery, useAction, useMutation } from "convex/react";
 import { api } from "../../convex/_generated/api";
 import { Id } from "../../convex/_generated/dataModel";
-import ReceiptCapture from "../components/ReceiptCapture";
 import ReceiptImageViewer from "../components/ReceiptImageViewer";
 import ClaimableItem from "../components/ClaimableItem";
 import JoinGate from "../components/JoinGate";
 import JoinToast from "../components/JoinToast";
 import TabNavigation from "../components/TabNavigation";
+import Items from "../components/Items";
 import Summary from "../components/Summary";
 import TaxTipSettings from "../components/TaxTipSettings";
 import { getStoredParticipant } from "../lib/sessionStorage";
@@ -52,6 +52,7 @@ export default function Session() {
     step: "idle",
   });
   const [activeTab, setActiveTab] = useState<Tab>("items");
+
   const [showReceiptImage, setShowReceiptImage] = useState(false);
 
   // State to track participant ID after just joining (before localStorage is read again)
@@ -442,220 +443,27 @@ export default function Session() {
         <div className="w-[72px] shrink-0" />
       </div>
 
-      {/* Single scroll content area */}
-      <div className="p-4">
-        {/* Items Tab */}
-        {activeTab === "items" && (
-          <div>
-            {/* Who's Here section */}
-            {participants && participants.length > 0 && (
-              <div className="mb-3">
-                <h2 className="text-lg font-semibold mb-2">
-                  Who's Here ({participants.length})
-                </h2>
-                <div className="flex flex-wrap gap-1.5">
-                  {[...participants]
-                    .sort((a, b) => a.joinedAt - b.joinedAt)
-                    .map((participant) => (
-                      <div
-                        key={participant._id}
-                        className="flex items-center gap-1 px-2 py-0.5 bg-gray-100 rounded-full text-sm"
-                      >
-                        <span className="font-medium">{participant.name}</span>
-                        {participant.isHost && (
-                          <span className="text-xs text-gray-500">(host)</span>
-                        )}
-                      </div>
-                    ))}
-                </div>
-              </div>
-            )}
+      <div>
+        <Outlet
+          context={
+            {
+              activeTab,
+              participants,
+              receiptState,
+              handleReceiptUpload,
+              handleRetry,
+              items,
+              session,
+              draftItem,
+              claims,
+              currentParticipantId,
+              isHost,
+              groupSubtotal,
+              fees: displayFees,
+            }
+          }
+        />
 
-            {/* Receipt section */}
-            <div className="mb-3">
-              <h2 className="text-lg font-semibold mb-2">Receipt</h2>
-
-              {/* Idle state: show capture UI */}
-              {receiptState.step === "idle" && (
-                <div>
-                  {session.receiptImageId && (
-                    <div className="mb-3">
-                      <p className="text-sm text-gray-600">
-                        Receipt uploaded. Upload a new one to replace existing
-                        items.
-                      </p>
-                      <button
-                        onClick={() => setShowReceiptImage(true)}
-                        className="text-sm text-blue-500 underline hover:text-blue-600"
-                      >
-                        View original receipt
-                      </button>
-                    </div>
-                  )}
-                  <ReceiptCapture
-                    sessionId={session._id}
-                    onUpload={handleReceiptUpload}
-                  />
-                </div>
-              )}
-
-              {/* Uploading state */}
-              {receiptState.step === "uploading" && (
-                <div className="text-center py-6">
-                  <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-500 mx-auto"></div>
-                  <p className="mt-3 text-gray-600">Uploading...</p>
-                </div>
-              )}
-
-              {/* Processing state */}
-              {receiptState.step === "processing" && (
-                <div className="text-center py-6">
-                  <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-500 mx-auto"></div>
-                  <p className="mt-3 text-gray-600">Analyzing receipt...</p>
-                  <p className="text-sm text-gray-500 mt-1">
-                    Extracting items with AI
-                  </p>
-                </div>
-              )}
-
-              {/* Error state */}
-              {receiptState.step === "error" && (
-                <div className="text-center py-6">
-                  <div className="text-red-500 mb-3">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      className="h-12 w-12 mx-auto"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      stroke="currentColor"
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        strokeWidth={2}
-                        d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-                      />
-                    </svg>
-                  </div>
-                  {receiptState.message.includes("\n\n") ? (
-                    <>
-                      <p className="text-red-600 font-medium">
-                        {receiptState.message.split("\n\n")[0]}
-                      </p>
-                      <p className="text-sm text-gray-600 mt-1">
-                        {receiptState.message.split("\n\n")[1]}
-                      </p>
-                    </>
-                  ) : (
-                    <>
-                      <p className="text-red-600 font-medium">
-                        Something went wrong
-                      </p>
-                      <p className="text-sm text-gray-600 mt-1">
-                        {receiptState.message}
-                      </p>
-                    </>
-                  )}
-                  <button
-                    onClick={handleRetry}
-                    className="mt-4 px-4 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600 transition-colors"
-                  >
-                    Try Again
-                  </button>
-                </div>
-              )}
-            </div>
-
-            {/* Items list */}
-            <div className="mb-3">
-              <div className="flex flex-row justify-between">
-                <h2 className="text-lg font-semibold mb-2">
-                  Items {items && items.length > 0 ? `(${items.length})` : ""}
-                </h2>
-                <div className="text-sm text-gray-400 pt-1">
-                  {session.merchant ? session.merchant : null}
-                </div>
-              </div>
-              <div className="space-y-1">
-                {items?.map((item) => (
-                  <ClaimableItem
-                    key={item._id}
-                    item={item}
-                    claims={(claims ?? []).filter((c) => c.itemId === item._id)}
-                    participants={participants ?? []}
-                    currentParticipantId={currentParticipantId}
-                    isHost={isHost}
-                  />
-                ))}
-              </div>
-
-              {/* Draft item - local only until saved */}
-              {draftItem && (
-                <ClaimableItem
-                  item={{
-                    _id: "" as Id<"items">,
-                    sessionId: session._id,
-                    name: draftItem.name,
-                    price: draftItem.price,
-                    quantity: draftItem.quantity,
-                  }}
-                  claims={[]}
-                  participants={participants ?? []}
-                  currentParticipantId={currentParticipantId}
-                  isHost={isHost}
-                  isDraft={true}
-                  onDraftSave={handleDraftSave}
-                  onDraftCancel={handleDraftCancel}
-                  onDraftChange={handleDraftChange}
-                />
-              )}
-
-              {/* Add item button - available to all participants */}
-              <button
-                onClick={() =>
-                  setDraftItem({ name: "", price: 0, quantity: 1 })
-                }
-                disabled={draftItem !== null}
-                className={`w-full mt-2 py-3 px-4 border-2 border-dashed rounded-lg transition-colors ${
-                  draftItem !== null
-                    ? "border-gray-200 text-gray-400 cursor-not-allowed"
-                    : "border-gray-300 text-gray-600 hover:border-gray-400 hover:text-gray-700"
-                }`}
-              >
-                + Add Item
-              </button>
-
-              {/* Items total */}
-              {items && items.length > 0 && (
-                <div className="mt-2 pt-2 border-t border-gray-200 flex justify-between items-center">
-                  <span className="font-medium">Items Total</span>
-                  <span className="font-semibold">
-                    ${(groupSubtotal / 100).toFixed(2)}
-                  </span>
-                </div>
-              )}
-            </div>
-          </div>
-        )}
-
-        {/* Tax & Tip Tab */}
-        {activeTab === "taxtip" && (
-          <TaxTipSettings
-            session={session}
-            fees={displayFees}
-            isHost={isHost}
-            groupSubtotal={groupSubtotal}
-            participantId={currentParticipantId}
-          />
-        )}
-
-        {/* Summary Tab */}
-        {activeTab === "summary" && (
-          <Summary
-            sessionId={session._id}
-            currentParticipantId={currentParticipantId}
-          />
-        )}
       </div>
 
       {/* Fixed Bottom Tab Navigation */}

--- a/src/pages/Session.tsx
+++ b/src/pages/Session.tsx
@@ -8,8 +8,6 @@ import JoinToast from "../components/JoinToast";
 import TabNavigation from "../components/TabNavigation";
 import { getStoredParticipant } from "../lib/sessionStorage";
 
-type Tab = "items" | "taxtip" | "summary";
-
 export default function Session() {
   const { code } = useParams<{ code: string }>();
   const [activeTab, setActiveTab] = useState<Tab>("items");

--- a/src/pages/Session.tsx
+++ b/src/pages/Session.tsx
@@ -1,59 +1,18 @@
 import { useState, useRef, useEffect, useMemo } from "react";
-import { useParams, Link, Route, Outlet, useLocation } from "react-router";
-import { useQuery, useAction, useMutation } from "convex/react";
+import { useParams, Link, Outlet } from "react-router";
+import { useQuery } from "convex/react";
 import { api } from "../../convex/_generated/api";
 import { Id } from "../../convex/_generated/dataModel";
-import ReceiptImageViewer from "../components/ReceiptImageViewer";
-import ClaimableItem from "../components/ClaimableItem";
 import JoinGate from "../components/JoinGate";
 import JoinToast from "../components/JoinToast";
 import TabNavigation from "../components/TabNavigation";
-import Items from "../components/Items";
-import Summary from "../components/Summary";
-import TaxTipSettings from "../components/TaxTipSettings";
 import { getStoredParticipant } from "../lib/sessionStorage";
-import { updateMerchantNameInBillHistory } from "../lib/billHistory";
-
-// Map rejection reasons to user-friendly error messages
-const REJECTION_MESSAGES: Record<string, { title: string; hint: string }> = {
-  landscape_photo: {
-    title: "This doesn't look like a receipt",
-    hint: "Try taking a photo of your receipt instead",
-  },
-  document: {
-    title: "This looks like a document, not a receipt",
-    hint: "Make sure you're photographing a store receipt",
-  },
-  blurry: {
-    title: "The image is too blurry",
-    hint: "Try taking another photo with better lighting",
-  },
-  other: {
-    title: "We couldn't recognize this as a receipt",
-    hint: "Try taking a clearer photo of your receipt",
-  },
-};
-
-// Confidence threshold for handwritten tip pre-fill (higher than receipt validation)
-const HANDWRITTEN_TIP_CONFIDENCE_THRESHOLD = 0.8;
-
-// Receipt processing state machine
-type ReceiptState =
-  | { step: "idle" }
-  | { step: "uploading" }
-  | { step: "processing"; storageId: Id<"_storage"> }
-  | { step: "error"; message: string };
 
 type Tab = "items" | "taxtip" | "summary";
 
 export default function Session() {
   const { code } = useParams<{ code: string }>();
-  const [receiptState, setReceiptState] = useState<ReceiptState>({
-    step: "idle",
-  });
   const [activeTab, setActiveTab] = useState<Tab>("items");
-
-  const [showReceiptImage, setShowReceiptImage] = useState(false);
 
   // State to track participant ID after just joining (before localStorage is read again)
   const [justJoinedParticipantId, setJustJoinedParticipantId] =
@@ -130,21 +89,6 @@ export default function Session() {
     return [];
   }, [fees, session?.tax]);
 
-  // Parse receipt action and mutations for saving items directly
-  const parseReceipt = useAction(api.actions.parseReceipt.parseReceipt);
-  const addBulk = useMutation(api.items.addBulk);
-  const addBulkFees = useMutation(api.fees.addBulk);
-  const updateTip = useMutation(api.sessions.updateTip);
-  const addItem = useMutation(api.items.add);
-  const updateMerchant = useMutation(api.sessions.updateMerchant);
-
-  // Draft item state - local only until saved
-  const [draftItem, setDraftItem] = useState<{
-    name: string;
-    price: number;
-    quantity: number;
-  } | null>(null);
-
   // Copy code state
   const [copied, setCopied] = useState(false);
 
@@ -195,110 +139,6 @@ export default function Session() {
     // Update ref for next comparison
     previousParticipantIdsRef.current = currentIds;
   }, [participants]);
-
-  // Handle receipt upload - triggers OCR processing and saves items directly
-  async function handleReceiptUpload(storageId: Id<"_storage">) {
-    if (!session) return;
-    setReceiptState({ step: "processing", storageId });
-
-    try {
-      const result = await parseReceipt({ storageId });
-
-      if ("error" in result) {
-        // Check for validation rejection (non-receipt)
-        if ("rejection_reason" in result && result.rejection_reason) {
-          const msg =
-            REJECTION_MESSAGES[result.rejection_reason] ||
-            REJECTION_MESSAGES.other;
-          setReceiptState({
-            step: "error",
-            message: `${msg.title}\n\n${msg.hint}`,
-          });
-          return;
-        }
-        // Existing parse error handling
-        const rawPreview =
-          "raw" in result && result.raw
-            ? `\n\nRaw response: ${result.raw.slice(0, 500)}`
-            : "";
-        setReceiptState({
-          step: "error",
-          message: `OCR failed: ${result.error}.${rawPreview}`,
-        });
-        return;
-      }
-
-      // Convert prices from dollars to cents and save items directly
-      const itemsInCents = result.items.map((item) => ({
-        name: item.name,
-        price: Math.round(item.price * 100),
-        quantity: item.quantity,
-      }));
-
-      if (!currentParticipantId) {
-        throw new Error("Must be joined to upload receipt");
-      }
-      await addBulk({
-        sessionId: session._id,
-        items: itemsInCents,
-        participantId: currentParticipantId,
-      });
-
-      if (result.merchant) {
-        await updateMerchant({
-          sessionId: session._id,
-          participantId: currentParticipantId,
-          merchant: result.merchant,
-        });
-        if (code) {
-          updateMerchantNameInBillHistory(code, result.merchant);
-        }
-      }
-
-      // Add fees from receipt (convert to cents)
-      if (result.fees && result.fees.length > 0) {
-        const feesInCents = result.fees.map((fee) => ({
-          label: fee.label,
-          amount: Math.round(fee.amount * 100),
-        }));
-        await addBulkFees({
-          sessionId: session._id,
-          participantId: currentParticipantId,
-          fees: feesInCents,
-        });
-      }
-
-      // Pre-fill tip from handwritten detection (silent - no toast per user decision)
-      if (
-        "handwritten_tip" in result &&
-        result.handwritten_tip?.detected &&
-        result.handwritten_tip.amount !== null &&
-        result.handwritten_tip.confidence >=
-          HANDWRITTEN_TIP_CONFIDENCE_THRESHOLD
-      ) {
-        await updateTip({
-          sessionId: session._id,
-          tipType: "manual",
-          tipValue: Math.round(result.handwritten_tip.amount * 100), // convert dollars to cents
-          participantId: currentParticipantId,
-        });
-      }
-
-      // Reset to idle - items are now visible via real-time query
-      setReceiptState({ step: "idle" });
-    } catch (error) {
-      setReceiptState({
-        step: "error",
-        message:
-          error instanceof Error ? error.message : "Unknown error occurred",
-      });
-    }
-  }
-
-  // Handle retry after error
-  function handleRetry() {
-    setReceiptState({ step: "idle" });
-  }
 
   // Loading state
   if (session === undefined) {
@@ -367,31 +207,6 @@ export default function Session() {
     }
   }
 
-  // Draft item handlers
-  async function handleDraftSave(
-    name: string,
-    price: number,
-    quantity: number,
-  ) {
-    if (!session || !currentParticipantId) return;
-    await addItem({
-      sessionId: session._id,
-      participantId: currentParticipantId,
-      name,
-      price,
-      quantity,
-    });
-    setDraftItem(null);
-  }
-
-  function handleDraftCancel() {
-    setDraftItem(null);
-  }
-
-  function handleDraftChange(name: string, price: number, quantity: number) {
-    setDraftItem({ name, price, quantity });
-  }
-
   return (
     <div className="max-w-md mx-auto pb-20">
       {/* Join notifications */}
@@ -447,14 +262,9 @@ export default function Session() {
         <Outlet
           context={
             {
-              activeTab,
               participants,
-              receiptState,
-              handleReceiptUpload,
-              handleRetry,
               items,
               session,
-              draftItem,
               claims,
               currentParticipantId,
               isHost,
@@ -472,15 +282,6 @@ export default function Session() {
         onTabChange={setActiveTab}
         unclaimedCount={unclaimedCount}
       />
-
-      {/* Receipt Image Viewer Modal */}
-      {session.receiptImageId && showReceiptImage && (
-        <ReceiptImageViewer
-          sessionId={session._id}
-          storageId={session.receiptImageId}
-          onClose={() => setShowReceiptImage(false)}
-        />
-      )}
     </div>
   );
 }

--- a/src/pages/Session.tsx
+++ b/src/pages/Session.tsx
@@ -8,9 +8,35 @@ import JoinToast from "../components/JoinToast";
 import TabNavigation from "../components/TabNavigation";
 import { getStoredParticipant } from "../lib/sessionStorage";
 
+export interface Fee {
+  _id: Id<"fees">;
+  label: string;
+  amount: number;
+}
+
+interface Session {
+  _id: Id<"sessions">;
+  gratuity?: number;
+  tipType?: "percent_subtotal" | "percent_total" | "manual";
+  tipValue?: number;
+  merchant?: string;
+  code?: string;
+  receiptImageId?: Id<"_storage">;
+}
+
+export interface Context {
+  fees: Fee[];
+  participants: any[];
+  session: Session;
+  items: any[];
+  isHost: boolean;
+  groupSubtotal: number;
+  claims: any[];
+  currentParticipantId: Id<"participants">;
+}
+
 export default function Session() {
   const { code } = useParams<{ code: string }>();
-  const [activeTab, setActiveTab] = useState<Tab>("items");
 
   // State to track participant ID after just joining (before localStorage is read again)
   const [justJoinedParticipantId, setJustJoinedParticipantId] =
@@ -68,7 +94,7 @@ export default function Session() {
   // Compute display fees with legacy fallback
   // New sessions: use fees from fees table
   // Legacy sessions: synthesize from session.tax if fees table is empty
-  const displayFees = useMemo(() => {
+  const displayFees: Fee[] = useMemo(() => {
     // If fees table has entries, use them
     if (fees && fees.length > 0) {
       return fees;
@@ -206,7 +232,7 @@ export default function Session() {
   }
 
   return (
-    <div className="max-w-md mx-auto pb-20">
+    <div>
       {/* Join notifications */}
       {joinToasts.slice(0, 1).map((toast) => (
         <JoinToast
@@ -276,8 +302,6 @@ export default function Session() {
 
       {/* Fixed Bottom Tab Navigation */}
       <TabNavigation
-        activeTab={activeTab}
-        onTabChange={setActiveTab}
         unclaimedCount={unclaimedCount}
       />
     </div>

--- a/src/pages/Session.tsx
+++ b/src/pages/Session.tsx
@@ -284,26 +284,21 @@ export default function Session() {
 
       <div>
         <Outlet
-          context={
-            {
-              participants,
-              items,
-              session,
-              claims,
-              currentParticipantId,
-              isHost,
-              groupSubtotal,
-              fees: displayFees,
-            }
-          }
+          context={{
+            participants,
+            items,
+            session,
+            claims,
+            currentParticipantId,
+            isHost,
+            groupSubtotal,
+            fees: displayFees,
+          }}
         />
-
       </div>
 
       {/* Fixed Bottom Tab Navigation */}
-      <TabNavigation
-        unclaimedCount={unclaimedCount}
-      />
+      <TabNavigation unclaimedCount={unclaimedCount} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Adds a QR code icon button to the right side of the session header (replacing the layout-balancing spacer), linking to a new `qr` sub-route
- New `QrCode` page renders a large centered SVG QR code for the session's join URL — no close button, users navigate away via the bottom tab bar
- Fixes `handleCopyCode` to always write the canonical bill URL (`origin + /bill/:code`) so the copy button and QR code share the same URL regardless of which sub-route is currently active

## Test plan

- [ ] Open a bill session — QR icon appears on the right side of the header
- [ ] Tap QR icon — URL changes to `/bill/:code/qr`, large QR code is centered on screen, bottom tab bar is visible
- [ ] Tap any bottom tab (Items, Tax & Tip, Totals) — navigates away from the QR page correctly
- [ ] Scan QR code with a phone — navigates to the bill join URL
- [ ] Tap copy button — copied URL matches the QR code URL (`origin + /bill/:code`)

---
_Generated by [Claude Code](https://claude.ai/code/session_011oR6ne2oQ82En9krPQFV9s)_