### PR TITLE
allow a user to delete their bills (sessions)

### DIFF
--- a/convex/sessions.ts
+++ b/convex/sessions.ts
@@ -24,6 +24,20 @@ export const getByCode = query({
   },
 });
 
+// Delete session by code
+export const deleteByCode = mutation({
+  args: { code: v.string() },
+  handler: async (ctx, args) => {
+    const normalizedCode = args.code.toUpperCase().trim();
+    const session = await ctx.db
+      .query("sessions")
+      .withIndex("by_code", (q) => q.eq("code", normalizedCode))
+      .first();
+    if (!session) return;
+    await ctx.db.delete("sessions", session._id);
+  }
+});
+
 // Get session by ID
 export const get = query({
   args: { id: v.id("sessions") },

--- a/convex/sessions.ts
+++ b/convex/sessions.ts
@@ -35,7 +35,7 @@ export const deleteByCode = mutation({
       .first();
     if (!session) return;
     await ctx.db.delete("sessions", session._id);
-  }
+  },
 });
 
 // Get session by ID

--- a/src/components/Summary.tsx
+++ b/src/components/Summary.tsx
@@ -6,8 +6,10 @@ import type { Context } from "../pages/Session";
 
 export default function Summary() {
   const context: Context = useOutletContext();
-  const { currentParticipantId } = context;
-  const totals = useQuery(api.participants.getTotals, { sessionId: context.session._id });
+  const { session, currentParticipantId } = context;
+  const totals = useQuery(api.participants.getTotals, {
+    sessionId: session._id,
+  });
 
   const [expandedParticipant, setExpandedParticipant] = useState<string | null>(
     null,

--- a/src/components/Summary.tsx
+++ b/src/components/Summary.tsx
@@ -2,15 +2,13 @@ import { useState } from "react";
 import { useQuery } from "convex/react";
 import { api } from "../../convex/_generated/api";
 import { useOutletContext } from "react-router";
-import { Context } from "../pages/Session";
+import type { Context } from "../pages/Session";
 
 export default function Summary() {
   const context: Context = useOutletContext();
-  const { session, currentParticipantId } = context;
+  const { currentParticipantId } = context;
+  const totals = useQuery(api.participants.getTotals, { sessionId: context.session._id });
 
-  const totals = useQuery(api.participants.getTotals, {
-    sessionId: session._id,
-  });
   const [expandedParticipant, setExpandedParticipant] = useState<string | null>(
     null,
   );

--- a/src/components/TabNavigation.tsx
+++ b/src/components/TabNavigation.tsx
@@ -79,7 +79,7 @@ export default function TabNavigation({
               to={id}
               key={id}
               className={({ isActive }) => {
-                const baseClasses = `flex-1 flex flex-col items-center justify-center py-2 min-h-[56px] transition-colors`;
+                const baseClasses = `flex-1 flex flex-col items-center justify-center py-2 min-h-14 transition-colors`;
                 return isActive
                   ? baseClasses + " text-blue-600"
                   : baseClasses + " text-gray-500";
@@ -90,7 +90,7 @@ export default function TabNavigation({
                   <div className="relative">
                     <Icon className="w-6 h-6" />
                     {id === "items" && unclaimedCount > 0 && (
-                      <span className="absolute -top-1 -right-2 bg-red-500 text-white text-xs font-medium rounded-full min-w-[18px] h-[18px] flex items-center justify-center px-1">
+                      <span className="absolute -top-1 -right-2 bg-red-500 text-white text-xs font-medium rounded-full min-w-4.5 h-4.5 flex items-center justify-center px-1">
                         {unclaimedCount}
                       </span>
                     )}

--- a/src/lib/billHistory.ts
+++ b/src/lib/billHistory.ts
@@ -103,7 +103,9 @@ export function updateMerchantNameInBillHistory(
  */
 export function clearOneBillFromHistory(sessionCode: string): void {
   if (!sessionCode) {
-    console.debug("You must provide a session code when clearing a bill from local storage.");
+    console.debug(
+      "You must provide a session code when clearing a bill from local storage.",
+    );
     return;
   }
   try {
@@ -113,13 +115,15 @@ export function clearOneBillFromHistory(sessionCode: string): void {
       return;
     }
     const normalizedCode = sessionCode.toUpperCase().trim();
-    const newBillHistory = billHistory.map(bill => {
-      if (bill.code.toUpperCase().trim() !== normalizedCode) {
-        return bill;
-      } else {
-        return null;
-      }
-    }).filter(session => session !== null);
+    const newBillHistory = billHistory
+      .map((bill) => {
+        if (bill.code.toUpperCase().trim() !== normalizedCode) {
+          return bill;
+        } else {
+          return null;
+        }
+      })
+      .filter((session) => session !== null);
     localStorage.setItem(STORAGE_KEY, JSON.stringify(newBillHistory));
   } catch {
     // Silently fail

--- a/src/lib/billHistory.ts
+++ b/src/lib/billHistory.ts
@@ -99,6 +99,34 @@ export function updateMerchantNameInBillHistory(
 }
 
 /**
+ * Clear a bill from history.
+ */
+export function clearOneBillFromHistory(sessionCode: string): void {
+  if (!sessionCode) {
+    console.debug("You must provide a session code when clearing a bill from local storage.");
+    return;
+  }
+  try {
+    const billHistory = getBillHistory();
+    if (!billHistory || billHistory.length === 0) {
+      console.debug(`There is no bill history data in local storage.`);
+      return;
+    }
+    const normalizedCode = sessionCode.toUpperCase().trim();
+    const newBillHistory = billHistory.map(bill => {
+      if (bill.code.toUpperCase().trim() !== normalizedCode) {
+        return bill;
+      } else {
+        return null;
+      }
+    }).filter(session => session !== null);
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(newBillHistory));
+  } catch {
+    // Silently fail
+  }
+}
+
+/**
  * Clear all bill history. Useful for testing or reset.
  */
 export function clearBillHistory(): void {

--- a/src/pages/Session.tsx
+++ b/src/pages/Session.tsx
@@ -1,12 +1,13 @@
 import { useState, useRef, useEffect, useMemo } from "react";
-import { useParams, Link, Outlet } from "react-router";
-import { useQuery } from "convex/react";
+import { useParams, Link, Outlet, useNavigate } from "react-router";
+import { useQuery, useMutation } from "convex/react";
 import { api } from "../../convex/_generated/api";
 import { Id, Doc } from "../../convex/_generated/dataModel";
 import JoinGate from "../components/JoinGate";
 import JoinToast from "../components/JoinToast";
 import TabNavigation from "../components/TabNavigation";
-import { getStoredParticipant } from "../lib/sessionStorage";
+import { getStoredParticipant, clearParticipant } from "../lib/sessionStorage";
+import { clearOneBillFromHistory } from "../lib/billHistory";
 
 export interface Context {
   fees: Doc<"fees">[];
@@ -21,6 +22,7 @@ export interface Context {
 
 export default function Session() {
   const { code } = useParams<{ code: string }>();
+  const navigate = useNavigate();
 
   // State to track participant ID after just joining (before localStorage is read again)
   const [justJoinedParticipantId, setJustJoinedParticipantId] =
@@ -28,6 +30,7 @@ export default function Session() {
 
   // Fetch session by code
   const session = useQuery(api.sessions.getByCode, code ? { code } : "skip");
+  const deleteSessionByCode = useMutation(api.sessions.deleteByCode);
 
   // Get stored participant ID from sessionStorage
   const storedParticipantId = useMemo(() => {
@@ -205,6 +208,13 @@ export default function Session() {
     }
   }
 
+  async function handleDeleteBillClick(code: string) {
+    await deleteSessionByCode({ code });
+    clearParticipant(code);
+    clearOneBillFromHistory(code);
+    navigate("/");
+  }
+
   return (
     <div>
       {/* Join notifications */}
@@ -253,7 +263,12 @@ export default function Session() {
         </button>
 
         {/* Spacer to balance back button width */}
-        <div className="w-18 shrink-0" />
+        <div
+          className="w-18 shrink-0"
+          onClick={() => handleDeleteBillClick(session.code)}
+        >
+          Delete
+        </div>
       </div>
 
       <div>

--- a/src/pages/Session.tsx
+++ b/src/pages/Session.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect, useMemo } from "react";
-import { useParams, Link, Route, Outlet, useLocation } from "react-router";
-import { useQuery, useAction, useMutation } from "convex/react";
+import { useParams, Link, Outlet } from "react-router";
+import { useQuery } from "convex/react";
 import { api } from "../../convex/_generated/api";
 import { Id, Doc } from "../../convex/_generated/dataModel";
 import JoinGate from "../components/JoinGate";
@@ -253,7 +253,7 @@ export default function Session() {
         </button>
 
         {/* Spacer to balance back button width */}
-        <div className="w-[72px] shrink-0" />
+        <div className="w-18 shrink-0" />
       </div>
 
       <div>

--- a/src/pages/Session.tsx
+++ b/src/pages/Session.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect, useMemo } from "react";
-import { useParams, Link, Outlet } from "react-router";
-import { useQuery } from "convex/react";
+import { useParams, Link, Route, Outlet, useLocation } from "react-router";
+import { useQuery, useAction, useMutation } from "convex/react";
 import { api } from "../../convex/_generated/api";
 import { Id, Doc } from "../../convex/_generated/dataModel";
 import JoinGate from "../components/JoinGate";


### PR DESCRIPTION
WIP - This PR adds the ability for a user to delete one of their bills.

So far this entails deleting the data for the bill in local storage as well as adding and utilizing a mutation to delete it from the database.

As it currently is, the session record is deleted from the db but I’m not sure how Convex handles deleting the other records associated with it: for example the `participant`s and `item`s.

Currently the delete button is in the header for the session, which is where the QR code clickable is added in https://github.com/osuvaldo90/split/pull/32. So that will have to be dealt with.

~This PR depends on and branches off of https://github.com/osuvaldo90/split/pull/28.~
**Update: the above PR has been merged**